### PR TITLE
Include OCR text in item search

### DIFF
--- a/inventory/views.py
+++ b/inventory/views.py
@@ -152,7 +152,7 @@ class AnnotateItemView(UserPassesTestMixin, UpdateView):
 
 class SearchableItemListView(UserPassesTestMixin, extra_views.SearchableListMixin, ListView):
     # matching criteria can be defined along with fields
-    search_fields = ["name", "category__name", "itemlocation__location__unique_identifier", "itemlocation__location__name"]
+    search_fields = ["name", "category__name", "itemlocation__location__unique_identifier", "itemlocation__location__name", "itemimage__ocr_text"]
     search_date_fields = []
     model = models.Item
     exact_query = False


### PR DESCRIPTION
Turns out that including the OCR text in the search is easier than i thought :). One downside: At the moment you don't see the OCR text in the overall search result list, even though it is considered for the search. If you would like this to be changed,  just let me know :)