### PR TITLE
bilder zu items im location-view hinzugefügt

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -16,3 +16,4 @@ django-bootstrap-icons
 tqdm
 pytesseract
 sorl-thumbnail
+setuptools


### PR DESCRIPTION
Ich konnte es nicht testen, weil auch in der dev-deployment irgendwelche keykloak dinge anspringen.

beim Versuch das development-env hochzuziehen kamen auch irgendwelche fehler beim datenbank-import...

also bitte nochmal testen, ob das so funktioniert.

nachdem die "entnehmen" und "verlegen" buttons noch keine Funktion haben, hab ich die mal wieder auskommentiert...